### PR TITLE
Create issue templates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[{*.yml,*.yaml}]
+indent_style = space

--- a/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/ISSUE_TEMPLATE/1-bug_report.yml
@@ -1,0 +1,56 @@
+name: "	🐛 Bug Report"
+description: "Something isn’t working as expected."
+title: "[Bug]: "
+labels: ["bug"]
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Thanks for reporting a bug!
+        Fill out the details below so we can reproduce and fix it.
+
+  - type: input
+    id: component
+    attributes:
+      label: "Component or URL"
+      description: "What part of the system is affected?"
+      placeholder: "/api/v1/login"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: "Steps to reproduce"
+      description: "Please be as detailed as possible."
+      placeholder: |
+        1. Go to …
+        2. Click on …
+        3. Scroll down to …
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: "Expected behavior"
+      description: "What should have happened?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: "Actual behavior"
+      description: "What actually happened? Include any error messages."
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: "Additional context & screenshots"
+      description: "Logs, stack traces, or screenshots that help explain the problem."

--- a/ISSUE_TEMPLATE/2-enhancement.yml
+++ b/ISSUE_TEMPLATE/2-enhancement.yml
@@ -1,0 +1,62 @@
+name: "✨ Enhancement Request"
+description: "Suggest a new feature or an improvement to an existing one."
+title: "[Enhancement]: "
+labels: ["enhancement"]
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Thanks for helping us improve!
+        Please complete the sections below so we fully understand your idea.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: "Summary"
+      description: "A concise description of the proposed enhancement."
+      placeholder: "It would be great if…"
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: "Problem / Opportunity"
+      description: "What pain point does this solve? Why is it valuable?"
+    validations:
+      required: false
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: "Proposed solution"
+      description: "Describe how you think this could be implemented."
+      placeholder: "I propose that we…"
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: "Acceptance criteria"
+      description: "How will we know the enhancement is complete?"
+      placeholder: |
+        * Given …
+        * When …
+        * Then …
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "Priority"
+      options:
+        - Low
+        - Medium
+        - High
+      description: "How urgent/important is this request?"
+    validations:
+      required: true

--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 🔒 Sensitive request (private)
+    url: mailto:info@philanthropydatacommons.org?subject=PDC%20request&body=Please%20describe%20your%20request%20here.
+    about: >
+      Use this link if your question or report contains **sensitive or private
+      information** (e.g., personal data, credentials, undisclosed security
+      vulnerabilities). It will open an email to our team instead of creating
+      a public issue.


### PR DESCRIPTION
This PR adds default issue templates for our repositories, and also helps direct users with sensitive requests to email us.

Note: team members with sensitive requests would be expected to use the `/internal` repository, but this PR's implementation opts for that to be a tacit process / the sensitive flow is intended for external uses who might want to raise an issue.

Related to https://github.com/PhilanthropyDataCommons/meta/issues/156