### PR TITLE
Adopt org issue types in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yml
@@ -1,7 +1,7 @@
 name: "	🐛 Bug Report"
 description: "Something isn’t working as expected."
 title: "[Bug]: "
-labels: ["bug"]
+type: "Bug"
 assignees: []
 
 body:

--- a/.github/ISSUE_TEMPLATE/2-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/2-enhancement.yml
@@ -1,7 +1,7 @@
 name: "✨ Enhancement Request"
 description: "Suggest a new feature or an improvement to an existing one."
 title: "[Enhancement]: "
-labels: ["enhancement"]
+type: "Feature"
 assignees: []
 
 body:


### PR DESCRIPTION
This PR updates our issue templates to use the Issue Types feature instead of labels.  This will let us use Issue Fields (even though we can't currently assign those)